### PR TITLE
TaggedDataContainer: Allow `add()` to be called multiple times with the same pair of tag and data pointer

### DIFF
--- a/src/Tags/TaggedDataContainer.php
+++ b/src/Tags/TaggedDataContainer.php
@@ -19,8 +19,6 @@ declare(strict_types=1);
 
 namespace Systopia\JsonSchema\Tags;
 
-use Systopia\JsonSchema\Exceptions\InvalidArgumentException;
-
 final class TaggedDataContainer implements TaggedDataContainerInterface
 {
     /**
@@ -33,31 +31,42 @@ final class TaggedDataContainer implements TaggedDataContainerInterface
      */
     private array $extra = [];
 
+    /**
+     * {@inheritDoc}
+     */
     public function add(string $tag, string $dataPointer, $data, $extra): void
     {
-        if ($this->has($tag, $dataPointer)) {
-            throw new InvalidArgumentException(sprintf('Data for tag "%s" at "%s" already exists', $tag, $dataPointer));
-        }
-
         $this->data[$tag][$dataPointer] = $data;
         $this->extra[$tag][$dataPointer] = $extra;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function get(string $tag, string $dataPointer)
     {
         return $this->data[$tag][$dataPointer] ?? null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function has(string $tag, string $dataPointer): bool
     {
         return \array_key_exists($dataPointer, $this->data[$tag] ?? []);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getAll(): array
     {
         return $this->data;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getByTag(string $tag): array
     {
         return $this->data[$tag] ?? [];
@@ -68,6 +77,9 @@ final class TaggedDataContainer implements TaggedDataContainerInterface
         return isset($this->data[$tag]);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getExtra(string $tag, string $dataPointer)
     {
         return $this->extra[$tag][$dataPointer] ?? null;

--- a/src/Tags/TaggedDataContainerInterface.php
+++ b/src/Tags/TaggedDataContainerInterface.php
@@ -22,6 +22,10 @@ namespace Systopia\JsonSchema\Tags;
 interface TaggedDataContainerInterface
 {
     /**
+     * If the method is called multiple times with the same pair of tag and data
+     * pointer, the last data will be available. This might happen e.g. in case
+     * of sub schemas.
+     *
      * @param null|mixed $data
      * @param null|mixed $extra
      */

--- a/tests/Tags/TaggedDataContainerTest.php
+++ b/tests/Tags/TaggedDataContainerTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 namespace Systopia\JsonSchema\Test\Tags;
 
 use PHPUnit\Framework\TestCase;
-use Systopia\JsonSchema\Exceptions\InvalidArgumentException;
 use Systopia\JsonSchema\Tags\TaggedDataContainer;
 
 /**
@@ -66,9 +65,5 @@ final class TaggedDataContainerTest extends TestCase
         self::assertSame(['/foo' => null], $container->getByTag('test2'));
         self::assertTrue($container->has('test2', '/foo'));
         self::assertNull($container->get('test2', '/foo'));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Data for tag "test" at "/foo" already exists');
-        $container->add('test', '/foo', 'exists', null);
     }
 }


### PR DESCRIPTION
This might happen e.g. in case of sub schemas.