### PR TITLE
Ensure that the final values are used for tagged data

### DIFF
--- a/src/Parsers/KeywordValidators/TagKeywordValidatorParser.php
+++ b/src/Parsers/KeywordValidators/TagKeywordValidatorParser.php
@@ -23,6 +23,7 @@ use Opis\JsonSchema\Info\SchemaInfo;
 use Opis\JsonSchema\KeywordValidator;
 use Opis\JsonSchema\Parsers\KeywordValidatorParser;
 use Opis\JsonSchema\Parsers\SchemaParser;
+use Systopia\JsonSchema\KeywordValidators\RootTagKeywordValidator;
 use Systopia\JsonSchema\KeywordValidators\TagKeywordValidator;
 
 final class TagKeywordValidatorParser extends KeywordValidatorParser
@@ -35,7 +36,7 @@ final class TagKeywordValidatorParser extends KeywordValidatorParser
     public function parse(SchemaInfo $info, SchemaParser $parser, object $shared): ?KeywordValidator
     {
         if (!$this->keywordExists($info)) {
-            return null;
+            return $info->isDocumentRoot() ? new RootTagKeywordValidator([]) : null;
         }
 
         $tags = (array) $this->keywordValue($info);
@@ -48,6 +49,10 @@ final class TagKeywordValidatorParser extends KeywordValidatorParser
             } else {
                 throw $this->keywordException('Invalid value for keyword {keyword}', $info);
             }
+        }
+
+        if ($info->isDocumentRoot()) {
+            return new RootTagKeywordValidator($parsedTags);
         }
 
         return [] === $parsedTags ? null : new TagKeywordValidator($parsedTags);

--- a/src/Parsers/SystopiaVocabulary.php
+++ b/src/Parsers/SystopiaVocabulary.php
@@ -59,13 +59,13 @@ class SystopiaVocabulary extends DefaultVocabulary
 
         $keywordValidators = array_merge(
             [
+                new TagKeywordValidatorParser(),
                 new CollectErrorsKeywordValidatorParser(),
                 new TypeKeywordValidatorParser(),
             ],
             $keywordValidators,
             [
                 new CalculateKeywordValidationParser(),
-                new TagKeywordValidatorParser(),
             ]
         );
 

--- a/src/Tags/TaggedDataContainerUtil.php
+++ b/src/Tags/TaggedDataContainerUtil.php
@@ -27,4 +27,14 @@ final class TaggedDataContainerUtil
     {
         return $context->globals()['taggedDataContainer'] ?? DummyTaggedDataContainer::getInstance();
     }
+
+    public static function getTaggedPathsContainer(ValidationContext $context): TaggedPathsContainer
+    {
+        return $context->globals()['taggedPathsContainer'];
+    }
+
+    public static function setTaggedPathsContainer(ValidationContext $context, TaggedPathsContainer $taggedPathsContainer): void
+    {
+        $context->setGlobals(['taggedPathsContainer' => $taggedPathsContainer]);
+    }
 }

--- a/src/Tags/TaggedPathsContainer.php
+++ b/src/Tags/TaggedPathsContainer.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2024 SYSTOPIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Systopia\JsonSchema\Tags;
+
+use Opis\JsonSchema\JsonPointer;
+
+/**
+ * The tagged data paths are collected here. Finally, the data is put into the
+ * tagged data container. This way it is ensured that the data container
+ * contain the final values, e.g. an array with tagged data might get sorted
+ * after the "$tag" keyword was applied to the items.
+ */
+final class TaggedPathsContainer
+{
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $extra = [];
+
+    /**
+     * @var array<string, list<string>>
+     */
+    private array $dataPointers = [];
+
+    /**
+     * @var array<string, list<int|string>>
+     */
+    private array $paths = [];
+
+    /**
+     * @param list<int|string> $path
+     * @param null|mixed $extra
+     */
+    public function add(string $tag, array $path, $extra): void
+    {
+        $dataPointer = JsonPointer::pathToString($path);
+        $this->paths[$dataPointer] = $path;
+        $this->dataPointers[$tag][] = $dataPointer;
+        $this->extra[$tag][$dataPointer] = $extra;
+    }
+
+    /**
+     * @param mixed $rootData
+     */
+    public function fillDataContainer($rootData, TaggedDataContainerInterface $dataContainer): void
+    {
+        foreach ($this->dataPointers as $tag => $dataPointers) {
+            foreach ($dataPointers as $dataPointer) {
+                $data = JsonPointer::getData($rootData, $this->paths[$dataPointer]);
+                $dataContainer->add($tag, $dataPointer, $data, $this->extra[$tag][$dataPointer]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
If the data was changed after the `$tag` was applied, e.g. an array was ordered, the tagged data container contained the data before the change.