### PR TITLE
Handle exceptions on calculate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
             "@php-cs-fixer fix -v --diff"
         ],
         "phpstan": [
-            "@php tools/phpstan/vendor/bin/phpstan"
+            "@php tools/phpstan/vendor/bin/phpstan -v"
         ],
         "phpunit": [
             "@php tools/phpunit/vendor/bin/simple-phpunit --coverage-clover clover.xml",

--- a/messages/de.php
+++ b/messages/de.php
@@ -100,7 +100,7 @@ return [
         other {Die Zahl darf nicht mehr als # Dezimalstellen haben.}
     }',
 
-    '$calculate.required.unresolved' => 'Der Wert wird benötigt, aber konnte nicht ermittelt werden aufgrund von nicht aufgelösten Variablen.',
+    '$calculate.required' => 'Der Wert wird benötigt, aber konnte nicht ermittelt werden aufgrund von ungültigen Daten oder nicht aufgelösten Variablen.',
 
     '_invalidData' => 'Ungültiger Wert für Schlüsselwort "{keyword}".',
     '_resolveFailed' => 'Auflösen des Werts für Schlüsselwort "{keyword}" ist fehlgeschlagen.',

--- a/src/Errors/ErrorCollectorUtil.php
+++ b/src/Errors/ErrorCollectorUtil.php
@@ -26,6 +26,10 @@ final class ErrorCollectorUtil
 {
     public static function getErrorCollector(ValidationContext $context): ErrorCollectorInterface
     {
+        if (!isset($context->globals()['errorCollector'])) {
+            self::setErrorCollector($context, new ErrorCollector());
+        }
+
         return $context->globals()['errorCollector'];
     }
 

--- a/src/Exceptions/CalculationFailedException.php
+++ b/src/Exceptions/CalculationFailedException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2022 SYSTOPIA GmbH
+ * Copyright 2025 SYSTOPIA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,6 @@
 
 declare(strict_types=1);
 
-namespace Systopia\JsonSchema\KeywordValidators;
+namespace Systopia\JsonSchema\Exceptions;
 
-use Opis\JsonSchema\ValidationContext;
-
-final class RootCollectErrorsKeywordValidator extends CollectErrorsKeywordValidator
-{
-    protected function shouldIgnoreError(ValidationContext $context): bool
-    {
-        return false;
-    }
-}
+class CalculationFailedException extends \RuntimeException implements ExceptionInterface {}

--- a/src/Expression/Calculation.php
+++ b/src/Expression/Calculation.php
@@ -80,13 +80,16 @@ final class Calculation
     }
 
     /**
+     * @param bool $violated Will be set to true, if false is given and one of
+     *                       the variables is violated
+     *
      * @return array<string, mixed>
      *
      * @throws ReferencedDataHasViolationException|VariableResolveException
      */
-    public function getVariables(ValidationContext $context, int $flags = 0): array
+    public function getVariables(ValidationContext $context, int $flags = 0, ?bool &$violated = null): array
     {
-        return $this->variablesContainer->getValues($context, $flags);
+        return $this->variablesContainer->getValues($context, $flags, $violated);
     }
 
     /**

--- a/src/Expression/CalculatorInterface.php
+++ b/src/Expression/CalculatorInterface.php
@@ -26,6 +26,8 @@ interface CalculatorInterface
      * @param array<string, mixed> $variables
      *
      * @return mixed
+     *
+     * @throws \Systopia\JsonSchema\Exceptions\CalculationFailedException
      */
     public function calculate(string $expression, array $variables = []);
 

--- a/src/Expression/ExpressionVariablesContainer.php
+++ b/src/Expression/ExpressionVariablesContainer.php
@@ -64,14 +64,20 @@ final class ExpressionVariablesContainer
     }
 
     /**
+     * @param bool $violated Will be set to true, if false is given and one of
+     *                       the variables is violated
+     *
      * @return array<string, mixed>
      *
      * @throws ReferencedDataHasViolationException|VariableResolveException
      */
-    public function getValues(ValidationContext $context, int $flags = 0): array
+    public function getValues(ValidationContext $context, int $flags = 0, ?bool &$violated = null): array
     {
         return array_map(
-            static fn (Variable $variable) => $variable->getValue($context, $flags),
+            // With lambda function $violated would not be set.
+            static function (Variable $variable) use ($context, $flags, &$violated) {
+                return $variable->getValue($context, $flags, $violated);
+            },
             $this->variables
         );
     }

--- a/src/Expression/SymfonyExpressionHandler.php
+++ b/src/Expression/SymfonyExpressionHandler.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace Systopia\JsonSchema\Expression;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Systopia\JsonSchema\Exceptions\CalculationFailedException;
 
 final class SymfonyExpressionHandler implements CalculatorInterface, EvaluatorInterface
 {
@@ -41,7 +42,13 @@ final class SymfonyExpressionHandler implements CalculatorInterface, EvaluatorIn
      */
     public function calculate(string $expression, array $variables = [])
     {
-        return $this->expressionLanguage->evaluate($expression, $variables);
+        try {
+            return $this->expressionLanguage->evaluate($expression, $variables);
+        }
+        // @phpstan-ignore catch.neverThrown
+        catch (\Throwable $e) {
+            throw new CalculationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     /**

--- a/src/Expression/Variables/IdentityVariable.php
+++ b/src/Expression/Variables/IdentityVariable.php
@@ -40,7 +40,7 @@ final class IdentityVariable extends Variable
     /**
      * {@inheritDoc}
      */
-    public function getValue(ValidationContext $context, int $flags = 0)
+    public function getValue(ValidationContext $context, int $flags = 0, ?bool &$violated = null)
     {
         return $this->value;
     }

--- a/src/Expression/Variables/Variable.php
+++ b/src/Expression/Variables/Variable.php
@@ -59,9 +59,12 @@ abstract class Variable
     }
 
     /**
+     * @param bool $violated Will be set to true, if false is given and the
+     *                       variable has violated data
+     *
      * @return null|mixed
      *
      * @throws ReferencedDataHasViolationException|VariableResolveException
      */
-    abstract public function getValue(ValidationContext $context, int $flags = 0);
+    abstract public function getValue(ValidationContext $context, int $flags = 0, ?bool &$violated = null);
 }

--- a/src/KeywordValidators/CalculateKeywordValidator.php
+++ b/src/KeywordValidators/CalculateKeywordValidator.php
@@ -26,10 +26,10 @@ use Opis\JsonSchema\Keywords\ErrorTrait;
 use Opis\JsonSchema\KeywordValidators\AbstractKeywordValidator;
 use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\ValidationContext;
+use Systopia\JsonSchema\Exceptions\ReferencedDataHasViolationException;
 use Systopia\JsonSchema\Exceptions\VariableResolveException;
 use Systopia\JsonSchema\Expression\Calculation;
 use Systopia\JsonSchema\Expression\Variables\CalculationVariable;
-use Systopia\JsonSchema\Expression\Variables\Variable;
 use Systopia\JsonSchema\Keywords\SetValueTrait;
 use Systopia\JsonSchema\Translation\ErrorTranslator;
 
@@ -50,11 +50,8 @@ final class CalculateKeywordValidator extends AbstractKeywordValidator
         $calculationVariable = new CalculationVariable($this->calculation);
 
         try {
-            $value = $calculationVariable->getValue(
-                $context,
-                Variable::FLAG_FAIL_ON_UNRESOLVED
-            );
-        } catch (VariableResolveException $e) {
+            $value = $calculationVariable->getValue($context);
+        } catch (ReferencedDataHasViolationException|VariableResolveException $e) {
             $value = null;
         }
 
@@ -78,7 +75,7 @@ final class CalculateKeywordValidator extends AbstractKeywordValidator
                 $schema,
                 $context,
                 '$calculate',
-                'The property is required, but could not be calculated because of unresolvable variables',
+                'The property is required, but could not be calculated because of invalid data or unresolvable variables',
                 [ErrorTranslator::TRANSLATION_ID_ARG_KEY => '$calculate.required.unresolved'],
             );
         }

--- a/tests/Expression/SymfonyExpressionHandlerTest.php
+++ b/tests/Expression/SymfonyExpressionHandlerTest.php
@@ -24,6 +24,7 @@ namespace Systopia\JsonSchema\Test\Expression;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Systopia\JsonSchema\Exceptions\CalculationFailedException;
 use Systopia\JsonSchema\Expression\SymfonyExpressionHandler;
 
 /**
@@ -82,6 +83,16 @@ final class SymfonyExpressionHandlerTest extends TestCase
             ->with('a * 2', ['a' => 2])->willReturn(123)
         ;
         self::assertSame(123, $this->expressionHandler->calculate('a * 2', ['a' => 2]));
+    }
+
+    public function testCalculateFail(): void
+    {
+        $exception = new \Exception('test', 123);
+        self::expectExceptionObject(new CalculationFailedException('test', 123, $exception));
+        $this->expressionLanguage->expects(self::once())->method('evaluate')
+            ->with('a * 2', ['a' => 2])->willThrowException($exception)
+        ;
+        $this->expressionHandler->calculate('a * 2', ['a' => 2]);
     }
 
     public function testValidateCalcExpressionFail(): void


### PR DESCRIPTION
Calculation is tried, even if one of the variables has a violation, because in case of objects the violated value might not be involved. Because of this approach the calculation might fail with an exception that must be handled.

systopia-reference: 27941