### PR TITLE
Fix handling of referenced data with ignored error

### DIFF
--- a/src/Errors/ErrorCollectorUtil.php
+++ b/src/Errors/ErrorCollectorUtil.php
@@ -37,4 +37,25 @@ final class ErrorCollectorUtil
     {
         $context->setGlobals(['errorCollector' => $errorCollector]);
     }
+
+    /**
+     * Returns an error collector for ignored errors when using the
+     * "$limitValidation" keyword.
+     */
+    public static function getIgnoredErrorCollector(ValidationContext $context): ErrorCollectorInterface
+    {
+        if (!isset($context->globals()['ignoredErrorCollector'])) {
+            self::setIgnoredErrorCollector($context, new ErrorCollector());
+        }
+
+        return $context->globals()['ignoredErrorCollector'];
+    }
+
+    /**
+     * Sets the error collector for ignored errors when using the "$limitValidation" keyword.
+     */
+    public static function setIgnoredErrorCollector(ValidationContext $context, ErrorCollectorInterface $errorCollector): void
+    {
+        $context->setGlobals(['ignoredErrorCollector' => $errorCollector]);
+    }
 }

--- a/src/Expression/Variables/JsonPointerVariable.php
+++ b/src/Expression/Variables/JsonPointerVariable.php
@@ -80,7 +80,8 @@ final class JsonPointerVariable extends Variable
         $path = $this->pointer->absolutePath($context->fullDataPath());
         Assertion::notNull($path);
 
-        $hasError = ErrorCollectorUtil::getErrorCollector($context)->hasErrorAt($path);
+        $hasError = ErrorCollectorUtil::getErrorCollector($context)->hasErrorAt($path)
+            || ErrorCollectorUtil::getIgnoredErrorCollector($context)->hasErrorAt($path);
         if (false === $violated) {
             $violated = $hasError;
         }

--- a/src/Expression/Variables/Variable.php
+++ b/src/Expression/Variables/Variable.php
@@ -60,7 +60,9 @@ abstract class Variable
 
     /**
      * @param bool $violated Will be set to true, if false is given and the
-     *                       variable has violated data
+     *                       variable has violated data. Ignored errors (when
+     *                       using "$limitValidation" keyword are regarded,
+     *                       too.)
      *
      * @return null|mixed
      *

--- a/src/KeywordValidators/ApplyLimitValidationKeywordValidator.php
+++ b/src/KeywordValidators/ApplyLimitValidationKeywordValidator.php
@@ -23,6 +23,7 @@ namespace Systopia\JsonSchema\KeywordValidators;
 use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\KeywordValidators\AbstractKeywordValidator;
 use Opis\JsonSchema\ValidationContext;
+use Systopia\JsonSchema\Errors\ErrorCollectorUtil;
 use Systopia\JsonSchema\LimitValidation\LimitValidationRule;
 
 class ApplyLimitValidationKeywordValidator extends AbstractKeywordValidator
@@ -52,7 +53,13 @@ class ApplyLimitValidationKeywordValidator extends AbstractKeywordValidator
     private function handleError(ValidationError $error, ValidationContext $context): ?ValidationError
     {
         if ('' !== $error->keyword()) {
-            return $this->shouldIgnoreError($error, $context) ? null : $error;
+            if ($this->shouldIgnoreError($error, $context)) {
+                ErrorCollectorUtil::getIgnoredErrorCollector($context)->addError($error);
+
+                return null;
+            }
+
+            return $error;
         }
 
         $subErrors = $error->subErrors();

--- a/src/Keywords/NoIntersectKeyword.php
+++ b/src/Keywords/NoIntersectKeyword.php
@@ -43,7 +43,9 @@ final class NoIntersectKeyword implements Keyword
 
     public function validate(ValidationContext $context, Schema $schema): ?ValidationError
     {
-        if (!ErrorCollectorUtil::getErrorCollector($context)->hasErrorAt($context->currentDataPath())) {
+        if (!ErrorCollectorUtil::getErrorCollector($context)->hasErrorAt($context->currentDataPath())
+            && !ErrorCollectorUtil::getIgnoredErrorCollector($context)->hasErrorAt($context->currentDataPath())
+        ) {
             /** @var list<\stdClass> $array */
             $array = $context->currentData();
             usort(

--- a/src/Keywords/OrderObjectsKeyword.php
+++ b/src/Keywords/OrderObjectsKeyword.php
@@ -46,6 +46,7 @@ final class OrderObjectsKeyword implements Keyword
     public function validate(ValidationContext $context, Schema $schema): ?ValidationError
     {
         if (!ErrorCollectorUtil::getErrorCollector($context)->hasErrorAt($context->currentDataPath())
+            && !ErrorCollectorUtil::getIgnoredErrorCollector($context)->hasErrorAt($context->currentDataPath())
             && 'array' === $context->currentDataType()
         ) {
             $this->setValue($context, function (array $array) {

--- a/src/Keywords/OrderSimpleKeyword.php
+++ b/src/Keywords/OrderSimpleKeyword.php
@@ -46,6 +46,7 @@ final class OrderSimpleKeyword implements Keyword
     public function validate(ValidationContext $context, Schema $schema): ?ValidationError
     {
         if (!ErrorCollectorUtil::getErrorCollector($context)->hasErrorAt($context->currentDataPath())
+            && !ErrorCollectorUtil::getIgnoredErrorCollector($context)->hasErrorAt($context->currentDataPath())
             && 'array' === $context->currentDataType()
         ) {
             $this->setValue($context, function (array $array) {

--- a/src/Parsers/KeywordValidators/LimitValidationKeywordParser.php
+++ b/src/Parsers/KeywordValidators/LimitValidationKeywordParser.php
@@ -68,7 +68,7 @@ final class LimitValidationKeywordParser extends KeywordValidatorParser
         } elseif (null !== LimitValidationKeywordValidator::getCurrentInstance()) {
             $condition = LimitValidationKeywordValidator::getCurrentInstance()->isConditionMatched();
         } else {
-            $condition = true;
+            $condition = false;
         }
 
         if (!\is_array($limitValidation->rules ?? [])) {
@@ -122,6 +122,9 @@ final class LimitValidationKeywordParser extends KeywordValidatorParser
                     'dependentRequired',
                 ],
             ],
+        ]);
+        $this->standardRules[] = LimitValidationRule::create([
+            'calculatedValueUsedViolatedData' => true,
         ]);
         $this->standardRules[] = LimitValidationRule::create(
             ['validate' => true]

--- a/src/Util/CalculateUtil.php
+++ b/src/Util/CalculateUtil.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2025 SYSTOPIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Systopia\JsonSchema\Util;
+
+use Opis\JsonSchema\ValidationContext;
+
+final class CalculateUtil
+{
+    public static function setCalculatedValueUsedViolatedData(
+        ValidationContext $context,
+        string $path,
+        bool $violatedDataUsed
+    ): void {
+        $valueUsedViolatedData = $context->globals()['calculatedValueUsedViolatedData'] ?? null;
+        if (null === $valueUsedViolatedData) {
+            $valueUsedViolatedData = new \ArrayObject();
+            $context->setGlobals(['calculatedValueUsedViolatedData' => $valueUsedViolatedData]);
+        }
+
+        $valueUsedViolatedData[$path] = $violatedDataUsed;
+    }
+
+    public static function wasViolatedDataUsedForCalculatedValue(ValidationContext $context, string $path): ?bool
+    {
+        return $context->globals()['calculatedValueUsedViolatedData'][$path] ?? null;
+    }
+}

--- a/tests/Errors/ErrorCollectorUtilTest.php
+++ b/tests/Errors/ErrorCollectorUtilTest.php
@@ -31,9 +31,20 @@ use Systopia\JsonSchema\Errors\ErrorCollectorUtil;
  */
 final class ErrorCollectorUtilTest extends TestCase
 {
-    public function testGetErrorCollector(): void
+    public function testErrorCollector(): void
     {
         $schemaLoader = new SchemaLoader();
+        $context = new ValidationContext(
+            '',
+            $schemaLoader,
+            null,
+            null
+        );
+
+        // A new error collector is set.
+        $errorCollector = ErrorCollectorUtil::getErrorCollector($context);
+        self::assertSame($errorCollector, ErrorCollectorUtil::getErrorCollector($context));
+
         $errorCollector = new ErrorCollector();
         $context = new ValidationContext(
             '',
@@ -43,5 +54,38 @@ final class ErrorCollectorUtilTest extends TestCase
             ['errorCollector' => $errorCollector]
         );
         self::assertSame($errorCollector, ErrorCollectorUtil::getErrorCollector($context));
+
+        $newErrorCollector = new ErrorCollector();
+        ErrorCollectorUtil::setErrorCollector($context, $newErrorCollector);
+        self::assertSame($newErrorCollector, ErrorCollectorUtil::getErrorCollector($context));
+    }
+
+    public function testIgnoredErrorCollector(): void
+    {
+        $schemaLoader = new SchemaLoader();
+        $context = new ValidationContext(
+            '',
+            $schemaLoader,
+            null,
+            null
+        );
+
+        // A new error collector is set.
+        $errorCollector = ErrorCollectorUtil::getIgnoredErrorCollector($context);
+        self::assertSame($errorCollector, ErrorCollectorUtil::getIgnoredErrorCollector($context));
+
+        $errorCollector = new ErrorCollector();
+        $context = new ValidationContext(
+            '',
+            $schemaLoader,
+            null,
+            null,
+            ['ignoredErrorCollector' => $errorCollector]
+        );
+        self::assertSame($errorCollector, ErrorCollectorUtil::getIgnoredErrorCollector($context));
+
+        $newErrorCollector = new ErrorCollector();
+        ErrorCollectorUtil::setIgnoredErrorCollector($context, $newErrorCollector);
+        self::assertSame($newErrorCollector, ErrorCollectorUtil::getIgnoredErrorCollector($context));
     }
 }

--- a/tests/Util/CalculateUtilTest.php
+++ b/tests/Util/CalculateUtilTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright 2025 SYSTOPIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Systopia\JsonSchema\Test\Util;
+
+use Opis\JsonSchema\SchemaLoader;
+use Opis\JsonSchema\ValidationContext;
+use PHPUnit\Framework\TestCase;
+use Systopia\JsonSchema\Util\CalculateUtil;
+
+/**
+ * @covers \Systopia\JsonSchema\Util\CalculateUtil
+ */
+final class CalculateUtilTest extends TestCase
+{
+    public function test(): void
+    {
+        $schemaLoader = new SchemaLoader();
+        $context = new ValidationContext(
+            '',
+            $schemaLoader,
+            null,
+            null
+        );
+
+        self::assertNull(CalculateUtil::wasViolatedDataUsedForCalculatedValue($context, '/test'));
+        CalculateUtil::setCalculatedValueUsedViolatedData($context, '/test', true);
+        self::assertTrue(CalculateUtil::wasViolatedDataUsedForCalculatedValue($context, '/test'));
+    }
+}


### PR DESCRIPTION
If referenced data e.g. in an expression had ignored validation errors this wasn't regarded before.

Follow up of #35.

systopia-reference: 28637